### PR TITLE
cleanBefore/-After & recursive Copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 [![Build Status](https://travis-ci.org/sakamotodesu/gradle-jcifs-tasks.svg?branch=master)](https://travis-ci.org/sakamotodesu/gradle-jcifs-tasks)
 [ ![Download](https://api.bintray.com/packages/sakamotodesu/maven/gradle-jcifs-tasks/images/download.svg) ](https://bintray.com/sakamotodesu/maven/gradle-jcifs-tasks/_latestVersion)
 
+http://dl.bintray.com/bbranquinho/gradle-jcifs-tasks
 
 jCifs Gradle Plugin provides cifs access function.
 
 - JcifsCopy : copy a file on the cifs server
+- Support copying recursively
 
 
 
@@ -20,11 +22,11 @@ buildscript {
     repositories {
         jcenter()
         maven {
-            url "http://dl.bintray.com/sakamotodesu/maven"
+            url "http://dl.bintray.com/bbranquinho/gradle-jcifs-tasks"
         }
     }
     dependencies {
-        classpath "github.com.sakamotodesu:gradle-jcifs-tasks:0.2.1"
+        classpath "github.com.sakamotodesu:gradle-jcifs-tasks:v0.3.0"
     }
 }
 
@@ -42,6 +44,7 @@ task copyCifs(type: github.com.sakamotodesu.JcifsCopy) {
     include '.*\\.zip'
     exclude '.*\\.txt'
     lmCompatibility '2'
+    recursivaly true
 }
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 [![Build Status](https://travis-ci.org/sakamotodesu/gradle-jcifs-tasks.svg?branch=master)](https://travis-ci.org/sakamotodesu/gradle-jcifs-tasks)
 [ ![Download](https://api.bintray.com/packages/sakamotodesu/maven/gradle-jcifs-tasks/images/download.svg) ](https://bintray.com/sakamotodesu/maven/gradle-jcifs-tasks/_latestVersion)
 
-http://dl.bintray.com/bbranquinho/gradle-jcifs-tasks
-
 jCifs Gradle Plugin provides cifs access function.
 
 - JcifsCopy : copy a file on the cifs server
-- Support copying recursively
 
 
 
@@ -22,11 +19,11 @@ buildscript {
     repositories {
         jcenter()
         maven {
-            url "http://dl.bintray.com/bbranquinho/gradle-jcifs-tasks"
+            url "http://dl.bintray.com/sakamotodesu/maven"
         }
     }
     dependencies {
-        classpath "github.com.sakamotodesu:gradle-jcifs-tasks:v0.3.0"
+        classpath "github.com.sakamotodesu:gradle-jcifs-tasks:0.2.1"
     }
 }
 
@@ -44,7 +41,7 @@ task copyCifs(type: github.com.sakamotodesu.JcifsCopy) {
     include '.*\\.zip'
     exclude '.*\\.txt'
     lmCompatibility '2'
-    recursivaly true
+    recursively true
 }
 </pre>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=github.com.sakamotodesu
 description=jCifs Gradle plugin
 
 # Leave as default
-version=0.2.2
+version=0.2.3
 
 # Uncomment if you want to upload the plugin to Maven Central
 #pom.url=https://github.com/example

--- a/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
@@ -71,7 +71,6 @@ class JcifsCopy extends DefaultTask {
                 }
             } else {
                 def dstFile = CopyFileFactory.get(dst, it.name)
-                println it
                 it.copyTo(dstFile)
             }
         }

--- a/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
@@ -16,6 +16,8 @@ class JcifsCopy extends DefaultTask {
     String lmCompatibility = 3
     String include
     String exclude
+    String cleanBefore = null
+    String cleanAfter = null
 
     @TaskAction
     def jcifsCopy() {
@@ -29,10 +31,16 @@ class JcifsCopy extends DefaultTask {
 
         def src = CopyFileFactory.get(from)
         def dst = CopyFileFactory.get(into)
-        println dst
+
+        if (cleanBefore != null) {
+            def cleanBeforeDir = CopyFileFactory.get(cleanBefore)
+            cleanBeforeDir.deleteDirectoryContents()
+        }
+
         if (!dst.exists()) {
             dst.mkdirs()
         }
+
         src.getFileList().findAll {
             if (include == null || include.isEmpty()) {
                 true
@@ -48,6 +56,11 @@ class JcifsCopy extends DefaultTask {
         }.each {
             def dstFile = CopyFileFactory.get(dst, it.getName())
             it.copyTo(dstFile)
+        }
+
+        if (cleanAfter != null) {
+            def cleanAfterDir = CopyFileFactory.get(cleanAfter)
+            cleanAfterDir.deleteDirectoryContents()
         }
     }
 

--- a/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/JcifsCopy.groovy
@@ -18,7 +18,7 @@ class JcifsCopy extends DefaultTask {
     String exclude
     String cleanBefore = null
     String cleanAfter = null
-    Boolean recursivaly = false
+    Boolean recursively = false
 
     @TaskAction
     def jcifsCopy() {
@@ -35,7 +35,7 @@ class JcifsCopy extends DefaultTask {
             cleanBeforeDir.deleteDirectoryContents()
         }
 
-        copyRecursivaly('')
+        copyRecursively('')
 
         if (cleanAfter != null) {
             def cleanAfterDir = CopyFileFactory.get(cleanAfter)
@@ -43,7 +43,7 @@ class JcifsCopy extends DefaultTask {
         }
     }
 
-    def copyRecursivaly(subPath) {
+    def copyRecursively(subPath) {
         def src = CopyFileFactory.get(from + subPath)
         def dst = CopyFileFactory.get(into + subPath)
 
@@ -52,7 +52,7 @@ class JcifsCopy extends DefaultTask {
         }
 
         src.getFileList().findAll {
-            if (include == null || include.isEmpty() || (it.isDirectory() && recursivaly)) {
+            if (include == null || include.isEmpty() || (it.isDirectory() && recursively)) {
                 true
             } else {
                 it.getName().matches(include)
@@ -65,9 +65,9 @@ class JcifsCopy extends DefaultTask {
             }
         }.each {
             if (it.isDirectory()) {
-                if (recursivaly) {
+                if (recursively) {
                     def sub = it.path.replaceFirst(from, '')
-                    copyRecursivaly(sub + '/')
+                    copyRecursively(sub + '/')
                 }
             } else {
                 def dstFile = CopyFileFactory.get(dst, it.name)

--- a/src/main/groovy/github/com/sakamotodesu/file/CopyFile.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/file/CopyFile.groovy
@@ -75,6 +75,12 @@ abstract class CopyFile {
     abstract List<CopyFile> getFileList()
 
     /**
+     *
+     * @return delete all files from the directory
+     */
+    abstract def deleteDirectoryContents()
+
+    /**
      * mkdirs
      */
     abstract void mkdirs()

--- a/src/main/groovy/github/com/sakamotodesu/file/LocalCopyFile.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/file/LocalCopyFile.groovy
@@ -32,11 +32,11 @@ class LocalCopyFile extends CopyFile {
     def isDirectory() {
         return localFile.isDirectory()
     }
+    
     /**
      *
      * @return {@inheritDoc}
      */
-
     @Override
     def getPath() {
         return localFile.getAbsolutePath()

--- a/src/main/groovy/github/com/sakamotodesu/file/LocalCopyFile.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/file/LocalCopyFile.groovy
@@ -87,6 +87,19 @@ class LocalCopyFile extends CopyFile {
     }
 
     /**
+     *
+     * @return {@inheritDoc}
+     */
+    @Override
+    def deleteDirectoryContents() {
+        if (localFile.isDirectory()) {
+            for (File file : localFile.listFiles()) {
+                file.directory ? file.deleteDir() : file.delete()
+            }
+        }
+    }
+
+    /**
      * mkdirs
      */
     @Override

--- a/src/main/groovy/github/com/sakamotodesu/file/SmbCopyFile.groovy
+++ b/src/main/groovy/github/com/sakamotodesu/file/SmbCopyFile.groovy
@@ -92,6 +92,19 @@ class SmbCopyFile extends CopyFile {
     }
 
     /**
+     *
+     * @return {@inheritDoc}
+     */
+    @Override
+    def deleteDirectoryContents() {
+        if (smbFile.isDirectory()) {
+            for (SmbFile file : smbFile.listFiles()) {
+                file.delete()
+            }
+        }
+    }
+
+    /**
      * mkdirs
      */
     @Override

--- a/src/test/groovy/github/com/sakamotodesu/JcifsCopyTest.groovy
+++ b/src/test/groovy/github/com/sakamotodesu/JcifsCopyTest.groovy
@@ -67,8 +67,6 @@ class JcifsCopyTest extends Specification {
         then:
         dstFile.exists()
     }
-    
-    
 
     def "copy local file to local file"() {
         given:
@@ -346,5 +344,44 @@ class JcifsCopyTest extends Specification {
         e.getCause() instanceof InvalidUserDataException
     }
 
+    def "empty dest dir before copy"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        setup()
+        def dstOldFile = new File(dstDir, "old.txt")
+        dstOldFile.createNewFile()
+        
+        when:
+        def task = project.task('test', type: JcifsCopy, {
+            from srcTextFile.getAbsolutePath()
+            into dstDir.getAbsolutePath()
+            cleanBefore dstDir.getAbsolutePath()
+        })
+        task.execute()
+        
+        then:
+        !dstOldFile.exists()
+        dstTextFile.exists()
+    }
+
+    def "empty src dir after copy"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        setup()
+
+        when:
+        def task = project.task('test', type: JcifsCopy, {
+            from srcTextFile.getAbsolutePath()
+            into dstDir.getAbsolutePath()
+            cleanAfter srcDir.getAbsolutePath()
+        })
+        task.execute()
+
+        then:
+        srcDir.exists()
+        !srcTextFile.exists()
+        !srcText2File.exists()
+        !srcZipFile.exists()
+    }
 
 }


### PR DESCRIPTION
It's been a while but I added a "cleanBefore" option (and a not-quite-as-useful sibling option "cleanAfter") which delete the contents of the given dir before or after copying.

Also bbranquinho implemented recursive copying which is also rather useful.

Maybe you want to merge this...